### PR TITLE
Cleanup some types

### DIFF
--- a/lib/xml/grammar.dart
+++ b/lib/xml/grammar.dart
@@ -2,8 +2,9 @@ part of xml;
 
 /**
  * XML grammar definition.
+ * Grammar of nodes ot type [TNode] with names of type [TName].
  */
-abstract class XmlGrammarDefinition extends GrammarDefinition {
+abstract class XmlGrammarDefinition<TNode, TName> extends GrammarDefinition {
 
   // name patterns
   static const NAME_START_CHARS =
@@ -35,15 +36,16 @@ abstract class XmlGrammarDefinition extends GrammarDefinition {
   static const CLOSE_PROCESSING = '?>';
 
   // parser callbacks
-  createAttribute(name, value);
-  createComment(value);
-  createCDATA(value);
-  createDoctype(value);
-  createDocument(Iterable children);
-  createElement(name, Iterable attributes, Iterable children);
-  createProcessing(target, value);
-  createQualified(name);
-  createText(value);
+  TNode createAttribute(TName name, String text);
+  TNode createComment(String text);
+  TNode createCDATA(String text);
+  TNode createDoctype(String text);
+  TNode createDocument(Iterable<TNode> children);
+  TNode createElement(TName name, Iterable<TNode> attributes,
+      Iterable<TNode> children);
+  TNode createProcessing(String target, String text);
+  TName createQualified(String name);
+  TNode createText(String text);
 
   // productions
   start() => ref(document).end();

--- a/lib/xml/nodes/element.dart
+++ b/lib/xml/nodes/element.dart
@@ -15,9 +15,9 @@ class XmlElement extends XmlBranch implements XmlNamed {
    */
   XmlElement(XmlName name, Iterable<XmlAttribute> attributes,
       Iterable<XmlNode> children)
-      : super(children),
-        name = name,
-        attributes = attributes.toList(growable: false) {
+      : name = name,
+        attributes = attributes.toList(growable: false),
+        super(children) {
     assert(this.name._parent == null);
     this.name._parent = this;
     for (var attribute in this.attributes) {

--- a/lib/xml/parser.dart
+++ b/lib/xml/parser.dart
@@ -3,7 +3,7 @@ part of xml;
 /**
  * XML parser that defines standard actions to the the XML tree.
  */
-class XmlParserDefinition extends XmlGrammarDefinition {
+class XmlParserDefinition extends XmlGrammarDefinition<XmlNode, XmlName> {
   @override
   XmlAttribute createAttribute(XmlName name, String text) =>
       new XmlAttribute(name, text);

--- a/lib/xml/utils/name.dart
+++ b/lib/xml/utils/name.dart
@@ -63,7 +63,7 @@ abstract class XmlName extends Object
   accept(XmlVisitor visitor) => visitor.visitName(this);
 
   @override
-  bool operator ==(Object other) => other is XmlName &&
+  bool operator ==(other) => other is XmlName &&
       other.local == local &&
       other.namespaceUri == namespaceUri;
 


### PR DESCRIPTION
Tweaked some method signatures to match the core libraries.
Added omitted typed signatures in XmlGrammarDefinition that existed elsewhere.
Matched style guide rule specifying that super call should appear last.