### PR TITLE
Enhancement for namespace manangement

### DIFF
--- a/lib/xml/utils/name.dart
+++ b/lib/xml/utils/name.dart
@@ -5,6 +5,7 @@ const _SEPARATOR = ':';
 
 // xml namespace declarations
 const _XML = 'xml';
+final _XML_META = new _NamespaceMeta(_XML, true);
 const _XML_URI = 'http://www.w3.org/XML/1998/namespace';
 const _XMLNS = 'xmlns';
 


### PR DESCRIPTION
Implemented: 
 - Allow omission of unused namespaces
 - Prevent duplicate namespace definition

Yet to be determined:
How to have users opt-in and opt-out for the change.

I made sure all checks happen in the relevant methods. So:

 - Omitting unused namespaces happens in the `element` method.
 - Preventing duplicate namespace definitions happens in the `namespace` method.

If I could chose, I'd add a boolean parameter to both the `namespace` and the `element` method, but I dislike random boolean parameters, so I would opt for named parameters. However, the `namespace` method already has an optional parameter, so a named parameter cannot be introduced without making a breaking change.

Another option is to add options to the `XmlBuilder` constructor...
