### PR TITLE
Fix attribute encoding: should also escape & and <

### DIFF
--- a/lib/xml/utils/entities.dart
+++ b/lib/xml/utils/entities.dart
@@ -342,6 +342,17 @@ final Pattern _TEXT_PATTERN = new RegExp(r'[&<]');
 
 /// Encode a string to be serialized as an XML attribute value.
 String _encodeXmlAttributeValue(String input) {
-  // only " needs to be encoded in attribute value
-  return input.replaceAll('"', '&quot;');
+  // only ", &, and < needs to be encoded in attribute value
+  return input.replaceAllMapped(_ATTRIBUTE_PATTERN, (match) {
+    switch (match.group(0)) {
+      case '"':
+        return '&quot;';
+      case '&':
+        return '&amp;';
+      case '<':
+        return '&lt;';
+    }
+  });
 }
+
+final Pattern _ATTRIBUTE_PATTERN = new RegExp(r'["&<]');

--- a/test/xml_test.dart
+++ b/test/xml_test.dart
@@ -362,7 +362,7 @@ void main() {
       XmlDocument document = parse('<data ns:attr="&lt;&gt;&amp;&apos;&quot;" />');
       XmlAttribute node = document.rootElement.attributes.single;
       expect(node.value, '<>&\'"');
-      expect(node.toString(), 'ns:attr="<>&\'&quot;"');
+      expect(node.toString(), 'ns:attr="&lt;>&amp;\'&quot;"');
     });
     test('attribute (single)', () {
       XmlDocument document = parse('<data ns:attr=\'Am I or are the other crazy?\' />');
@@ -390,7 +390,7 @@ void main() {
       XmlDocument document = parse('<data ns:attr=\'&lt;&gt;&amp;&apos;&quot;\' />');
       XmlAttribute node = document.rootElement.attributes.single;
       expect(node.value, '<>&\'"');
-      expect(node.toString(), 'ns:attr="<>&\'&quot;"');
+      expect(node.toString(), 'ns:attr="&lt;>&amp;\'&quot;"');
     });
     test('text', () {
       XmlDocument document = parse('<data>Am I or are the other crazy?</data>');


### PR DESCRIPTION
According to [the spec](https://www.w3.org/TR/REC-xml/#NT-AttValue), XML attribute values should also escape `<` and `&` in addition to their opening quote character.

These changes update `_encodeXmlAttributeValue` and its tests to follow that.