### PR TITLE
fix attribute value escaping

### DIFF
--- a/lib/xml/utils/entities.dart
+++ b/lib/xml/utils/entities.dart
@@ -357,8 +357,8 @@ final Map<XmlAttributeType, String> _attributeQuote = {
 };
 
 final Map<XmlAttributeType, Pattern> _attributePattern = {
-  XmlAttributeType.SINGLE_QUOTE: new RegExp(r"['&<]"),
-  XmlAttributeType.DOUBLE_QUOTE: new RegExp(r'["&<]')
+  XmlAttributeType.SINGLE_QUOTE: new RegExp(r"['&<\n\r\t]"),
+  XmlAttributeType.DOUBLE_QUOTE: new RegExp(r'["&<\n\r\t]')
 };
 
 final Map<XmlAttributeType, _ReplaceFunction> _attributeReplace = {
@@ -370,6 +370,12 @@ final Map<XmlAttributeType, _ReplaceFunction> _attributeReplace = {
         return '&amp;';
       case '<':
         return '&lt;';
+      case '\n':
+        return '&#xA;';
+      case '\r':
+        return '&#xD;';
+      case '\t':
+        return '&#x9;';
     }
   },
   XmlAttributeType.DOUBLE_QUOTE: (Match match) {
@@ -380,6 +386,12 @@ final Map<XmlAttributeType, _ReplaceFunction> _attributeReplace = {
         return '&amp;';
       case '<':
         return '&lt;';
+      case '\n':
+        return '&#xA;';
+      case '\r':
+        return '&#xD;';
+      case '\t':
+        return '&#x9;';
     }
   },
 };


### PR DESCRIPTION
See Canonical XML chapter 5.2
https://www.w3.org/TR/2000/WD-xml-c14n-20000119.html#charescaping

In attribute values, the character information items TAB (#x9), newline
(#xA), and carriage-return (#xD) are represented by "&#x9;", "&#xA;",
and "&#xD;" respectively.

This fix is necessary to correctly keep newlines character as well as tab char in XML attribute values, otherwise these characters are replaced with single blank space by all other compliant participants.