### PR TITLE
inserting xml nodes as they are rather then text

### DIFF
--- a/lib/xml/builder.dart
+++ b/lib/xml/builder.dart
@@ -196,6 +196,8 @@ class XmlBuilder {
       value();
     } else if (value is Iterable) {
       value.forEach(_insert);
+    } else if (value is XmlNode){
+      _stack.last.children.add(value);
     } else {
       text(value.toString());
     }


### PR DESCRIPTION
Just added another check for the _insert function - in case that the value is of an XmlNode type the function will insert it directly as an XmlNode rather than translating it into text and adding it as a text node.