### PR TITLE
Allow update after reading XML file

### DIFF
--- a/lib/xml/nodes/element.dart
+++ b/lib/xml/nodes/element.dart
@@ -19,7 +19,7 @@ class XmlElement extends XmlParent implements XmlNamed {
 
   /// Create an [XmlElement] with the given `name`, `attributes`, and `children`.
   XmlElement(this.name, Iterable<XmlAttribute> attributes, Iterable<XmlNode> children)
-      : attributes = attributes.toList(growable: false),
+      : attributes = attributes.toList(),
         super(children) {
     name.adoptParent(this);
     for (var attribute in this.attributes) {

--- a/lib/xml/nodes/parent.dart
+++ b/lib/xml/nodes/parent.dart
@@ -10,7 +10,7 @@ abstract class XmlParent extends XmlNode {
   final List<XmlNode> children;
 
   /// Create a node with a list of `children`.
-  XmlParent(Iterable<XmlNode> children) : children = children.toList(growable: false) {
+  XmlParent(Iterable<XmlNode> children) : children = children.toList() {
     for (var child in this.children) {
       child.adoptParent(this);
     }


### PR DESCRIPTION
After reading XML file, it's not possible to update it.
See code below.

```
node.children.insert(insert, newNode);
Unsupported operation: Cannot add from a fixed-length list
#0      ListBase&&FixedLengthListMixin.removeAt (dart:_internal/list.dart:61)
```