### PR TITLE
Missing mutable attribute value

### DIFF
--- a/lib/xml/nodes/attribute.dart
+++ b/lib/xml/nodes/attribute.dart
@@ -12,14 +12,25 @@ class XmlAttribute extends XmlNode implements XmlNamed {
   @override
   final XmlName name;
 
+  String _value;
+
   /// Return the value of the attribute.
-  final String value;
+  String get value => _value;
+
+  /// Update the value of the attribute.
+  set value(String value) {
+    if (value == null) {
+      throw new ArgumentError.notNull('value');
+    }
+    _value = value;
+  }
 
   /// Return the quote type.
   final XmlAttributeType attributeType;
 
   /// Create an attribute with `name` and `value`.
-  XmlAttribute(this.name, this.value, [this.attributeType = XmlAttributeType.DOUBLE_QUOTE]) {
+  XmlAttribute(this.name, String value, [this.attributeType = XmlAttributeType.DOUBLE_QUOTE]) {
+    this.value = value;
     name.attachParent(this);
   }
 

--- a/lib/xml/nodes/data.dart
+++ b/lib/xml/nodes/data.dart
@@ -1,13 +1,26 @@
 library xml.nodes.data;
 
 import 'package:xml/xml/nodes/node.dart' show XmlNode;
+import 'package:xml/xml/utils/errors.dart' show XmlNodeTypeError;
 
 /// Abstract XML data node.
 abstract class XmlData extends XmlNode {
+  String _text;
+
   /// Return the textual value of this node.
   @override
-  String text;
+  String get text => _text;
+
+  /// Update the textual value of this node.
+  set text(String text) {
+    if (text == null) {
+      throw new ArgumentError.notNull('text');
+    }
+    _text = text;
+  }
 
   /// Create a data section with `text`.
-  XmlData(this.text);
+  XmlData(String text) {
+    this.text = text;
+  }
 }

--- a/test/xml_test.dart
+++ b/test/xml_test.dart
@@ -610,6 +610,65 @@ void main() {
         assertTreeInvariants(document);
       });
     }
+    group('update', () {
+      mutatingTest(
+        'element (attribute value)',
+        '<element attr="value" />',
+            (node) => node.attributes.first.value = 'update',
+        '<element attr="update" />',
+      );
+      throwingTest(
+        'element (null attribute value)',
+        '<element attr="value" />',
+            (node) => node.attributes.first.value = null,
+        throwsArgumentError,
+      );
+      mutatingTest(
+        'cdata (text)',
+        '<element><![CDATA[text]]></element>',
+            (node) => (node.children.first as XmlCDATA).text = 'update',
+        '<element><![CDATA[update]]></element>',
+      );
+      throwingTest(
+        'cdata (null text)',
+        '<element><![CDATA[text]]></element>',
+            (node) => (node.children.first as XmlCDATA).text = null,
+        throwsArgumentError,
+      );
+      mutatingTest(
+        'comment (text)',
+        '<element><!--comment--></element>',
+            (node) => (node.children.first as XmlComment).text = 'update',
+        '<element><!--update--></element>',
+      );
+      throwingTest(
+        'comment (null text)',
+        '<element><!--comment--></element>',
+            (node) => (node.children.first as XmlComment).text = null,
+        throwsArgumentError,
+      );
+      test('processing (text)', () {
+        var document = parse('<?xml processing?><element />');
+        (document.firstChild as XmlProcessing).text = 'update';
+        expect(document.toXmlString(), '<?xml update?><element />');
+      });
+      test('processing (null text)', () {
+        var document = parse('<?xml processing ?><element />');
+        expect(() => (document.firstChild as XmlProcessing).text = null, throwsArgumentError);
+      });
+      mutatingTest(
+        'text (text)',
+        '<element>Hello World</element>',
+            (node) => (node.children.first as XmlText).text = 'Dart rocks',
+        '<element>Dart rocks</element>',
+      );
+      throwingTest(
+        'text (null text)',
+        '<element>Hello World</element>',
+            (node) => (node.children.first as XmlText).text = null,
+        throwsArgumentError,
+      );
+    });
     group('add', () {
       mutatingTest(
         'element (attributes)',


### PR DESCRIPTION
Only attribute value mutation was missing.

Element/attribute name don't need to be mutable.
In fact, use case is mostly this one:
- remove element/attribute
- create new element/attribute
- add to parent