### PR TITLE
Push style XmlReader

### DIFF
--- a/lib/xml.dart
+++ b/lib/xml.dart
@@ -26,7 +26,7 @@ export 'xml/reader.dart' show XmlReader, XmlPushReader;
 export 'xml/utils/attribute_type.dart' show XmlAttributeType;
 export 'xml/utils/name.dart' show XmlName;
 export 'xml/utils/named.dart' show XmlNamed;
-export 'xml/utils/node_type.dart' show XmlNodeType;
+export 'xml/utils/node_type.dart' show XmlNodeType, XmlPushReaderNodeType;
 export 'xml/utils/owned.dart' show XmlOwned;
 export 'xml/utils/writable.dart' show XmlWritable;
 export 'xml/visitors/transformer.dart' show XmlTransformer;

--- a/lib/xml.dart
+++ b/lib/xml.dart
@@ -22,7 +22,7 @@ export 'xml/nodes/parent.dart' show XmlParent;
 export 'xml/nodes/processing.dart' show XmlProcessing;
 export 'xml/nodes/text.dart' show XmlText;
 export 'xml/parser.dart' show XmlParserDefinition;
-export 'xml/reader.dart' show XmlReader, XmlTextReader;
+export 'xml/reader.dart' show XmlReader, XmlPushReader;
 export 'xml/utils/attribute_type.dart' show XmlAttributeType;
 export 'xml/utils/name.dart' show XmlName;
 export 'xml/utils/named.dart' show XmlNamed;

--- a/lib/xml.dart
+++ b/lib/xml.dart
@@ -22,7 +22,7 @@ export 'xml/nodes/parent.dart' show XmlParent;
 export 'xml/nodes/processing.dart' show XmlProcessing;
 export 'xml/nodes/text.dart' show XmlText;
 export 'xml/parser.dart' show XmlParserDefinition;
-export 'xml/reader.dart' show XmlReader;
+export 'xml/reader.dart' show XmlReader, XmlTextReader;
 export 'xml/utils/attribute_type.dart' show XmlAttributeType;
 export 'xml/utils/name.dart' show XmlName;
 export 'xml/utils/named.dart' show XmlNamed;

--- a/lib/xml/reader.dart
+++ b/lib/xml/reader.dart
@@ -1,5 +1,7 @@
 library xml.reader;
 
+import 'dart:collection';
+
 import 'package:petitparser/petitparser.dart';
 import 'package:xml/xml/nodes/attribute.dart';
 import 'package:xml/xml/nodes/element.dart';
@@ -7,6 +9,7 @@ import 'package:xml/xml/parser.dart';
 import 'package:xml/xml/production.dart';
 import 'package:xml/xml/utils/name.dart';
 import 'package:xml/xml/utils/node_list.dart';
+import 'package:xml/xml/utils/node_type.dart';
 import 'package:xml/xml/utils/token.dart';
 
 // Definition of the XML productions.
@@ -140,4 +143,148 @@ class XmlReader {
     onParseError?.call(context.position);
     return context.success(null, context.position + 1);
   }
+}
+
+/// A push based XmlReader interface, intended to be similar to .NET's XmlReader.
+class XmlTextReader {
+  /// Creates a new reader for `input`.
+  /// 
+  /// Setting `ignoreWhitespace` to false will cause text nodes 
+  XmlTextReader(String input, {this.ignoreWhitespace = true}) {
+    _result = Success(input, 0, null);
+    _depth = 0;
+    _eof = false;
+  }
+
+  /// If true, will ignore `XmlNodeType.TEXT` and when it is composed of whitespace.
+  bool ignoreWhitespace;
+
+  /// Parsing context.
+  Result _result;
+
+  /// The [XmlNodeType] of the current position of the reader.
+  XmlNodeType get nodeType => _nodeType;
+  XmlNodeType _nodeType;
+
+  /// The [XmlName] of the current node of the reader.
+  XmlName get name => _name;
+  XmlName _name;
+
+  /// The value of the current node of the reader.
+  ///
+  /// The value will have
+  String get value => _value;
+  String _value;
+
+  /// Will return true if `nodeType == XmlNodeType.ELEMENT` and the element is self closing,
+  /// e.g. `<element />`.
+  bool get isEmptyElement => _isEmptyElement;
+  bool _isEmptyElement;
+
+  /// The zero based depth of the reader.
+  int get depth => _depth;
+  int _depth;
+
+  /// True if the reader is positioned at the end of the buffer.
+  bool get eof => _eof;
+  bool _eof;
+
+  /// The `List<XmlAttribute>` of the current element (if `nodeType == XmlNodeType.ELEMENT`).
+  UnmodifiableListView<XmlAttribute> get attributes =>
+      UnmodifiableListView<XmlAttribute>(_attributes);
+  List<XmlAttribute> _attributes;
+
+  /// Advances the reader to the next readable position.  Returns true if more data remains, false if not.
+  bool read() {
+    if (_result.position > _result.buffer.length) {
+      _eof = true;
+      return false;
+    }
+
+    _result = _parseEvent(_result);
+    return (_result.isSuccess);
+  }
+
+  Result _parseEvent(Result context) {
+    _attributes = <XmlAttribute>[];
+    _isEmptyElement = null;
+    _value = null;
+    _nodeType = null;
+
+    Result result = _characterData.parseOn(context);
+    if (result.isSuccess) {
+      _nodeType = XmlNodeType.TEXT;
+      _value = result.value.trim();
+      if (_value == '') {
+        return _parseEvent(result);
+      }
+      return result;
+    }
+
+    result = _elementStart.parseOn(context);
+    if (result.isSuccess) {
+      _nodeType = XmlNodeType.ELEMENT;
+      _name = result.value[1];
+      _depth++;
+      _attributes = List<XmlAttribute>.from(result.value[2]);
+      if (result.value[4] == XmlToken.closeEndElement) {
+        _depth--;
+        _isEmptyElement = true;
+      } else {
+        _isEmptyElement = false;
+      }
+      return result;
+    }
+
+    result = _elementEnd.parseOn(context);
+    if (result.isSuccess) {
+      _nodeType = XmlNodeType.ELEMENT;
+      _name = result.value[1];
+      _depth--;
+      return result;
+    }
+
+    result = _comment.parseOn(context);
+    if (result.isSuccess) {
+      _nodeType = XmlNodeType.COMMENT;
+      _value = result.value[1];
+      return result;
+    }
+
+    // Parse CDATA as character data:
+    result = _cdata.parseOn(context);
+    if (result.isSuccess) {
+      _nodeType = XmlNodeType.CDATA;
+      _value = result.value[1];
+      return result;
+    }
+
+    // Parse processing instruction:
+    result = _processing.parseOn(context);
+    if (result.isSuccess) {
+      _nodeType = XmlNodeType.PROCESSING;
+      _value = result.value[2];
+      return result;
+    }
+
+    // Parse docytpes:
+    result = _doctype.parseOn(context);
+    if (result.isSuccess) {
+      _nodeType = XmlNodeType.DOCUMENT_TYPE;
+      _value = result.value[2];
+      return result;
+    }
+
+    if (context.position == context.buffer.length) {
+      _eof = true;
+      return context.failure('EOF');
+    }
+    // Skip to the next character when there is a problem:
+    return context.success(null, context.position + 1);
+  }
+
+  @override
+  String toString() => eof
+      ? 'XmlTextReader{EOF}'
+      : 'XmlTextReader{$depth $nodeType $name $value $attributes}';
 }

--- a/lib/xml/reader.dart
+++ b/lib/xml/reader.dart
@@ -154,6 +154,11 @@ class XmlPushReader {
   bool _isEmptyElement;
 
   /// The zero based depth of the reader.
+  ///
+  /// Depth is calculated as follows:
+  /// * Every [XmlPushReaderNodeType.ELEMENT] will increment the reader's depth by 1.
+  /// * Every [XmlPushReaderNodeType.END_ELEMENT] will decrement the reader's depth by 1.
+  /// * An empty element (e.g. `<element />`) will increment the reader's depth by 1 while in focus, and then decrement it by 1 on the next call to [read].
   int get depth => _depth;
   int _depth;
 

--- a/lib/xml/reader.dart
+++ b/lib/xml/reader.dart
@@ -113,7 +113,9 @@ class XmlReader {
 class XmlPushReader {
   /// Creates a new reader for `input`.
   ///
-  /// Setting `ignoreWhitespace` to false will cause text nodes
+  /// Setting `ignoreWhitespace` to false will cause all ignorable whitespace to be trimmed.
+  /// Setting the `onParseError` callback will enable error processing; otherwise, the parser
+  /// will attempt to silentl ignore errors and continue parsing if possible.
   XmlPushReader(String input,
       {this.ignoreWhitespace = true, this.onParseError}) {
     _result = Success(input, 0, null);

--- a/lib/xml/reader.dart
+++ b/lib/xml/reader.dart
@@ -148,8 +148,8 @@ class XmlReader {
 /// A push based XmlReader interface, intended to be similar to .NET's XmlReader.
 class XmlTextReader {
   /// Creates a new reader for `input`.
-  /// 
-  /// Setting `ignoreWhitespace` to false will cause text nodes 
+  ///
+  /// Setting `ignoreWhitespace` to false will cause text nodes
   XmlTextReader(String input, {this.ignoreWhitespace = true}) {
     _result = Success(input, 0, null);
     _depth = 0;
@@ -207,6 +207,11 @@ class XmlTextReader {
 
   Result _parseEvent(Result context) {
     _attributes = <XmlAttribute>[];
+
+    if (_isEmptyElement == true) {
+      _depth--;
+    }
+
     _isEmptyElement = null;
     _value = null;
     _nodeType = null;
@@ -228,7 +233,7 @@ class XmlTextReader {
       _depth++;
       _attributes = List<XmlAttribute>.from(result.value[2]);
       if (result.value[4] == XmlToken.closeEndElement) {
-        _depth--;
+        // _depth--;
         _isEmptyElement = true;
       } else {
         _isEmptyElement = false;
@@ -238,7 +243,7 @@ class XmlTextReader {
 
     result = _elementEnd.parseOn(context);
     if (result.isSuccess) {
-      _nodeType = XmlNodeType.ELEMENT;
+      _nodeType = XmlNodeType.END_ELEMENT;
       _name = result.value[1];
       _depth--;
       return result;

--- a/lib/xml/utils/node_type.dart
+++ b/lib/xml/utils/node_type.dart
@@ -2,13 +2,24 @@ library xml.utils.node_type;
 
 /// Enum of the different XML Node types.
 enum XmlNodeType {
+  /// An element start or self-closed tag, e.g. `<item>` or `<item />`.
   ELEMENT,
+  /// An element closing tag, e.g. `</item>`.
+  END_ELEMENT,
+  /// An attribute, e.g. `id="123"`.
   ATTRIBUTE,
+  /// Text content within a node.
   TEXT,
+  /// Raw character data (CDATA), e.g.  `<![CDATA[escaped text]]>`.
   CDATA,
+  /// A processing instruction, e.g. `<?pi test?>`.
   PROCESSING,
+  /// A comment, e.g. `<!-- comment -->`.
   COMMENT,
+  /// A document object.
   DOCUMENT,
+  /// A document fragment.
   DOCUMENT_FRAGMENT,
+  /// A document type declaration, e.g. `<!DOCTYPE...>`.
   DOCUMENT_TYPE
 }

--- a/lib/xml/utils/node_type.dart
+++ b/lib/xml/utils/node_type.dart
@@ -23,3 +23,26 @@ enum XmlNodeType {
   /// A document type declaration, e.g. `<!DOCTYPE...>`.
   DOCUMENT_TYPE
 }
+
+/// Enum of the different XML Node types that [xml.reader.XmlPushReader] emits.
+///
+/// This is a subset of [XmlNodeType], as [xml.reader.XmlPushReader] does not
+/// emit [XmlNodeType.DOCUMENT] or [XmlNodeType.DOCUMENT_FRAGMENT] node types.
+/// It also does not emit [XmlNodeType.ATTRIBUTE]s, instead providing accessors
+/// for them when parsing an [XmlPushReaderNodeType.ELEMENT].
+enum XmlPushReaderNodeType {
+  /// An element start or self-closed tag, e.g. `<item>` or `<item />`.
+  ELEMENT,
+  /// An element closing tag, e.g. `</item>`.
+  END_ELEMENT,
+  /// Text content within a node.
+  TEXT,
+  /// Raw character data (CDATA), e.g.  `<![CDATA[escaped text]]>`.
+  CDATA,
+  /// A processing instruction, e.g. `<?pi test?>`.
+  PROCESSING,
+  /// A comment, e.g. `<!-- comment -->`.
+  COMMENT,
+  /// A document type declaration, e.g. `<!DOCTYPE...>`.
+  DOCUMENT_TYPE
+}

--- a/lib/xml/utils/node_type.dart
+++ b/lib/xml/utils/node_type.dart
@@ -4,22 +4,31 @@ library xml.utils.node_type;
 enum XmlNodeType {
   /// An element start or self-closed tag, e.g. `<item>` or `<item />`.
   ELEMENT,
+
   /// An element closing tag, e.g. `</item>`.
   END_ELEMENT,
+
   /// An attribute, e.g. `id="123"`.
   ATTRIBUTE,
+
   /// Text content within a node.
   TEXT,
+
   /// Raw character data (CDATA), e.g.  `<![CDATA[escaped text]]>`.
   CDATA,
+
   /// A processing instruction, e.g. `<?pi test?>`.
   PROCESSING,
+
   /// A comment, e.g. `<!-- comment -->`.
   COMMENT,
+
   /// A document object.
   DOCUMENT,
+
   /// A document fragment.
   DOCUMENT_FRAGMENT,
+
   /// A document type declaration, e.g. `<!DOCTYPE...>`.
   DOCUMENT_TYPE
 }
@@ -33,16 +42,22 @@ enum XmlNodeType {
 enum XmlPushReaderNodeType {
   /// An element start or self-closed tag, e.g. `<item>` or `<item />`.
   ELEMENT,
+
   /// An element closing tag, e.g. `</item>`.
   END_ELEMENT,
+
   /// Text content within a node.
   TEXT,
+
   /// Raw character data (CDATA), e.g.  `<![CDATA[escaped text]]>`.
   CDATA,
+
   /// A processing instruction, e.g. `<?pi test?>`.
   PROCESSING,
+
   /// A comment, e.g. `<!-- comment -->`.
   COMMENT,
+
   /// A document type declaration, e.g. `<!DOCTYPE...>`.
   DOCUMENT_TYPE
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ description: A lightweight library for parsing, traversing, querying, transformi
 homepage: https://github.com/renggli/dart-xml
 
 environment:
-  sdk: ^2.0.0
+  sdk: ">=2.0.0-dev.69 <3.0.0"
 dependencies:
   petitparser: ^2.0.0
   collection: ^1.14.0

--- a/test/reader_test.dart
+++ b/test/reader_test.dart
@@ -67,44 +67,46 @@ void main() {
     while (reader.read()) {
       switch (reader.nodeType) {
         case XmlPushReaderNodeType.ELEMENT:
-          events.add('<${reader.name.qualified}>');
+          events.add('${reader.depth}: <${reader.name.qualified}>');
           if (reader.isEmptyElement) {
-            events.add('</${reader.name.qualified}>');
+            events.add('${reader.depth}: </${reader.name.qualified}>');
           }
           break;
         case XmlPushReaderNodeType.END_ELEMENT:
-          events.add('</${reader.name.qualified}>');
+          events.add('${reader.depth}: </${reader.name.qualified}>');
           break;
         case XmlPushReaderNodeType.CDATA:
         case XmlPushReaderNodeType.TEXT:
-          events.add(reader.value);
+          events.add('${reader.depth}: ${reader.value}');
           break;
         case XmlPushReaderNodeType.PROCESSING:
           events
-              .add('<?${reader.processingInstructionTarget} ${reader.value}?>');
+              .add('${reader.depth}: <?${reader.processingInstructionTarget} ${reader.value}?>');
           break;
         case XmlPushReaderNodeType.DOCUMENT_TYPE:
-          events.add('<!DOCTYPE ${reader.value}>');
+          events.add('${reader.depth}: <!DOCTYPE ${reader.value}>');
           break;
         case XmlPushReaderNodeType.COMMENT:
-          events.add('<!--${reader.value}-->');
+          events.add('${reader.depth}: <!--${reader.value}-->');
           break;
         default:
           throw StateError('unreachable');
       }
     }
+    expect(reader.depth, 0);
+    expect(reader.eof, isTrue);
     expect(events, [
-      '<?xml foo?>',
-      '<!DOCTYPE name [ something ]>',
-      '<ns:foo>',
-      '<element>',
-      '</element>',
-      '<ns:element>',
-      '</ns:element>',
-      '<!-- comment -->',
-      'cdata',
-      '<?processing instruction?>',
-      '</ns:foo>',
+      '0: <?xml foo?>',
+      '0: <!DOCTYPE name [ something ]>',
+      '1: <ns:foo>',
+      '2: <element>',
+      '2: </element>',
+      '2: <ns:element>',
+      '2: </ns:element>',
+      '1: <!-- comment -->',
+      '1: cdata',
+      '1: <?processing instruction?>',
+      '0: </ns:foo>',
     ]);
   });
 }


### PR DESCRIPTION
This is meant to be a .NET style XmlReader.

Rather than using SAX-style callbacks, consumers call `read()` to push the reader ahead and then can view the state (node type, node name, node value, attributes, etc.).

The most significant differences between the internal parsing logic for the SAX reader:
- Keeps track of attributes, depth, node type, node name, as state on the reader
- Tracks closing elements a little differently

This could, in theory, be rewritten as a sync generator with some kind of state object - but in such a case, it might be a little harder to manipulate for use cases where you want to pass control of iteration around to various functions/classes (e.g. you want to read just a subtree and then pass control back to the original reader).