### PR TITLE
remember namespaceUri when converting toXmlNodes

### DIFF
--- a/lib/src/xml/utils/name.dart
+++ b/lib/src/xml/utils/name.dart
@@ -23,20 +23,23 @@ abstract class XmlName extends Object
 
   /// Creates a qualified [XmlName] from a `local` name and an optional
   /// `prefix`.
-  factory XmlName(String local, [String prefix]) =>
+  factory XmlName(String local, [String prefix, String namespaceUri]) =>
       prefix == null || prefix.isEmpty
-          ? XmlSimpleName(local)
-          : XmlPrefixName(prefix, local, '$prefix${XmlToken.namespace}$local');
+          ? XmlSimpleName(local, namespaceUri: namespaceUri)
+          : XmlPrefixName(
+            prefix, local, '$prefix${XmlToken.namespace}$local',
+            namespaceUri: namespaceUri);
 
   /// Create a [XmlName] by parsing the provided `qualified` name.
-  factory XmlName.fromString(String qualified) {
+  factory XmlName.fromString(String qualified, {String namespaceUri}) {
     final index = qualified.indexOf(XmlToken.namespace);
     if (index > 0) {
       final prefix = qualified.substring(0, index);
       final local = qualified.substring(index + 1);
-      return XmlPrefixName(prefix, local, qualified);
+      return XmlPrefixName(prefix, local, qualified,
+                           namespaceUri: namespaceUri);
     } else {
-      return XmlSimpleName(qualified);
+      return XmlSimpleName(qualified, namespaceUri: namespaceUri);
     }
   }
 

--- a/lib/src/xml/utils/prefix_name.dart
+++ b/lib/src/xml/utils/prefix_name.dart
@@ -12,8 +12,13 @@ class XmlPrefixName extends XmlName {
   @override
   final String qualified;
 
-  @override
-  String get namespaceUri => lookupAttribute(parent, xmlns, prefix)?.value;
+  final String _namespaceUri;
 
-  XmlPrefixName(this.prefix, this.local, this.qualified) : super.internal();
+  @override
+  String get namespaceUri =>
+    _namespaceUri ?? lookupAttribute(parent, xmlns, prefix)?.value;
+
+  XmlPrefixName(this.prefix, this.local, this.qualified, {String namespaceUri}):
+    _namespaceUri = namespaceUri,
+    super.internal();
 }

--- a/lib/src/xml/utils/simple_name.dart
+++ b/lib/src/xml/utils/simple_name.dart
@@ -12,8 +12,13 @@ class XmlSimpleName extends XmlName {
   @override
   String get qualified => local;
 
-  @override
-  String get namespaceUri => lookupAttribute(parent, null, xmlns)?.value;
+  final String _namespaceUri;
 
-  XmlSimpleName(this.local) : super.internal();
+  @override
+  String get namespaceUri =>
+    _namespaceUri ?? lookupAttribute(parent, null, xmlns)?.value;
+
+  XmlSimpleName(this.local, {String namespaceUri}) :
+    _namespaceUri = namespaceUri,
+    super.internal();
 }

--- a/lib/src/xml_events/converters/node_decoder.dart
+++ b/lib/src/xml_events/converters/node_decoder.dart
@@ -84,7 +84,7 @@ class _XmlNodeDecoderSink extends ChunkedConversionSink<List<XmlEvent>>
   @override
   void visitStartElementEvent(XmlStartElementEvent event) {
     final element = XmlElement(
-      XmlName.fromString(event.name),
+      XmlName.fromString(event.name, namespaceUri: event.namespaceUri),
       convertAttributes(event.attributes),
       [],
       event.isSelfClosing,


### PR DESCRIPTION
This is a rough attempt to get namespaceUri added to XmlElements when `toXmlNodes` is used to process a stream where `withNamespace` was already used.