### PR TITLE
Optionally add a space before auto-closing an element

### DIFF
--- a/lib/src/xml/mixins/has_writer.dart
+++ b/lib/src/xml/mixins/has_writer.dart
@@ -32,6 +32,8 @@ mixin XmlHasWriter implements XmlHasVisitor {
   ///   whitespace are preserved.
   /// - If the [sortAttributes] is provided, attributes are on-the-fly sorted
   ///   using the provided [Comparator].
+  /// - If the predicate [spaceBeforeSelfClose] returns `true`, self-closing
+  ///   elements will be closed with a space before the slash ('<example />')
   ///
   String toXmlString({
     bool pretty = false,
@@ -42,17 +44,21 @@ mixin XmlHasWriter implements XmlHasVisitor {
     Predicate<XmlNode>? preserveWhitespace,
     Predicate<XmlAttribute>? indentAttribute,
     Comparator<XmlAttribute>? sortAttributes,
+    Predicate<XmlNode>? spaceBeforeSelfClose,
   }) {
     final buffer = StringBuffer();
     final writer = pretty
-        ? XmlPrettyWriter(buffer,
+        ? XmlPrettyWriter(
+            buffer,
             entityMapping: entityMapping,
             level: level,
             indent: indent,
             newLine: newLine,
             preserveWhitespace: preserveWhitespace,
             indentAttribute: indentAttribute,
-            sortAttributes: sortAttributes)
+            sortAttributes: sortAttributes,
+            spaceBeforeSelfClose: spaceBeforeSelfClose,
+          )
         : XmlWriter(buffer, entityMapping: entityMapping);
     writer.visit(this);
     return buffer.toString();

--- a/lib/src/xml/visitors/pretty_writer.dart
+++ b/lib/src/xml/visitors/pretty_writer.dart
@@ -21,6 +21,7 @@ class XmlPrettyWriter extends XmlWriter {
   final Predicate<XmlNode>? preserveWhitespace;
   final Predicate<XmlAttribute>? indentAttribute;
   final Comparator<XmlAttribute>? sortAttributes;
+  final Predicate<XmlNode>? spaceBeforeSelfClose;
 
   XmlPrettyWriter(
     StringSink buffer, {
@@ -31,6 +32,7 @@ class XmlPrettyWriter extends XmlWriter {
     this.preserveWhitespace,
     this.indentAttribute,
     this.sortAttributes,
+    this.spaceBeforeSelfClose,
   })  : level = level ?? 0,
         indent = indent ?? '  ',
         newLine = newLine ?? '\n',
@@ -48,6 +50,9 @@ class XmlPrettyWriter extends XmlWriter {
     visit(node.name);
     writeAttributes(node);
     if (node.children.isEmpty && node.isSelfClosing) {
+      if (spaceBeforeSelfClose != null && spaceBeforeSelfClose!(node)) {
+        buffer.write(' ');
+      }
       buffer.write(XmlToken.closeEndElement);
     } else {
       buffer.write(XmlToken.closeElement);

--- a/test/visitor_test.dart
+++ b/test/visitor_test.dart
@@ -278,6 +278,34 @@ void main() {
             '<c c="3" b="2" a="1">CCC</c>'
             '</body>');
       });
+      test('insert space before self-closing', () {
+        final element = XmlElement(
+          XmlName('base'),
+          [],
+          [
+            XmlElement(XmlName('simple')),
+            XmlElement(
+              XmlName('with-attributes'),
+              [XmlAttribute(XmlName('attr'), 'val')],
+            ),
+            XmlElement(XmlName('do-not-add')),
+          ],
+        );
+
+        final output = element.toXmlString(
+          pretty: true,
+          spaceBeforeSelfClose: (node) =>
+              node is XmlElement && node.name.local != 'do-not-add',
+        );
+        expect(
+          output,
+          '<base>\n'
+          '  <simple />\n'
+          '  <with-attributes attr="val" />\n'
+          '  <do-not-add/>\n'
+          '</base>',
+        );
+      });
     });
   });
 }


### PR DESCRIPTION
Adds a predicate parameter to the pretty printer to insert a space character before self-closing an element.

Fixes #109 