### PR TITLE
compare attributes explicitly

### DIFF
--- a/test/assertions.dart
+++ b/test/assertions.dart
@@ -366,11 +366,18 @@ void compareNode(XmlNode first, XmlNode second) {
   expect(firstText, secondText);
   expect(first.attributes.length, second.attributes.length);
   for (var i = 0; i < first.attributes.length; i++) {
-    compareNode(first.attributes[i], second.attributes[i]);
+    compareAttribute(first.attributes[i], second.attributes[i]);
   }
   if (first is! XmlHasChildren) {
     expect(first.toXmlString(), second.toXmlString());
   }
+}
+
+void compareAttribute(XmlAttribute first, XmlAttribute second) {
+  expect(first.name.qualified, second.name.qualified);
+  expect(first.name.namespaceUri, second.name.namespaceUri);
+  expect(first.attributeType, second.attributeType);
+  expect(first.value, second.value);
 }
 
 void assertPrintingInvariants(XmlNode xml) {


### PR DESCRIPTION
I had some concerns about the validity of the tests regarding the control characters. 

My concern was that the tests would mainly see if the `toXmlString` would result in the same `String`, but that the documents would not be identical.

To see if my concern was valid, I modified the escaping algorithm. In `default_mapping.dart`, I changed
```Dart
String _asNumericCharacterReferences(String toEscape) => toEscape.runes
    .map((rune) =>'&#x$rune.toRadixString(16).toUpperCase()};')
    .join();
```
into
```Dart
String _asNumericCharacterReferences(String toEscape) => toEscape.runes
    .map((rune) =>
        '&#x${(rune == 7 ? 6 : rune).toRadixString(16).toUpperCase()};')
    .join();
```
Basically, this mean that a `\u0007` is converted to `&#x6;`. And that will be parsed to `\u0006`, which in turn would also be converted to `&#x6;`.

The good news is: the code works great. They did detected the problem in `text` nodes. But the tests did not catch this malicious trick if the `\0007` was in an attribute value.

This pull request improves how attributes are compared.