### PR TITLE
Export XmlSimpleName and XmlPrefixName

### DIFF
--- a/lib/xml.dart
+++ b/lib/xml.dart
@@ -49,7 +49,10 @@ export 'src/xml/utils/attribute_type.dart' show XmlAttributeType;
 export 'src/xml/utils/flatten.dart' show XmlFlattenIterableExtension;
 export 'src/xml/utils/name.dart' show XmlName;
 export 'src/xml/utils/node_type.dart' show XmlNodeType;
+export 'src/xml/utils/prefix_name.dart' show XmlPrefixName;
+export 'src/xml/utils/simple_name.dart' show XmlSimpleName;
 export 'src/xml/utils/token.dart' show XmlToken;
+
 export 'src/xml/visitors/normalizer.dart' show XmlNormalizerExtension;
 export 'src/xml/visitors/pretty_writer.dart' show XmlPrettyWriter;
 export 'src/xml/visitors/transformer.dart'


### PR DESCRIPTION
Added XmlSimpleName and XmlPrefixName in the export, so we can do a check on `element.name` (element is XmlElement) to see which type it is