### PR TITLE
Draft: feat: implement equality operators

### DIFF
--- a/lib/src/xml/mixins/has_name.dart
+++ b/lib/src/xml/mixins/has_name.dart
@@ -1,7 +1,7 @@
 import '../utils/name.dart';
 
 /// Mixin for all nodes with a name.
-mixin XmlHasName {
+mixin XmlHasName implements Comparable<XmlHasName> {
   /// Return the name of the node.
   XmlName get name;
 
@@ -16,4 +16,7 @@ mixin XmlHasName {
 
   /// Return the namespace URI, or `null`.
   String? get namespaceUri => name.namespaceUri;
+
+  @override
+  int compareTo(XmlHasName other) => name.compareTo(other.name);
 }

--- a/lib/src/xml/mixins/xml_camparable.dart
+++ b/lib/src/xml/mixins/xml_camparable.dart
@@ -1,0 +1,73 @@
+import 'package:collection/collection.dart';
+
+/// Mixin for comparable XML nodes
+///
+/// Please note, this mixin does not aim to check whether XmlNodes are composed
+/// the same way, but implements some checks on whether XML encoded *data* is
+/// equal in two XmlNode representations.
+///
+/// Features ignored in comparisons:
+/// - namespace prefixes - only the namespace URLs are compared
+/// - namespace declarations
+/// - empty text nodes
+/// - comments
+///
+/// This code is mostly based on parts of `package:equatable`
+mixin XmlComparable {
+  /// List of properties to be compared
+  List<Object?> get comparable;
+
+  /// additional comparison to be applied on each == operator
+  ///
+  /// return values:
+  /// - false: objects are not equal
+  /// - true:objects are equal
+  /// - null: rely on default [comparable] fallback
+  bool? additionalComparator(Object other) => null;
+
+  @override
+  int get hashCode => _finish(comparable.fold(0, _combine));
+
+  @override
+  bool operator ==(Object other) {
+    final additionalComparison = additionalComparator(other);
+    // in case the custom comparison is `false` or `true`, immediately return
+    return additionalComparison != false &&
+        (additionalComparison == true ||
+            identical(other, this) ||
+            (other is XmlComparable && other.hashCode == hashCode));
+  }
+
+  /// Jenkins Hash Functions
+  /// https://en.wikipedia.org/wiki/Jenkins_hash_function
+  int _combine(int hash, dynamic object) {
+    if (object is Map) {
+      object.keys
+          .sorted((dynamic a, dynamic b) => a.hashCode - b.hashCode)
+          .forEach((dynamic key) {
+        hash = hash ^ _combine(hash, <dynamic>[key, (object as Map)[key]]);
+      });
+      return hash;
+    }
+    if (object is Set) {
+      object =
+          object.sorted(((dynamic a, dynamic b) => a.hashCode - b.hashCode));
+    }
+    if (object is Iterable) {
+      for (final value in object) {
+        hash = hash ^ _combine(hash, value);
+      }
+      return hash ^ object.length;
+    }
+
+    hash = 0x1fffffff & (hash + object.hashCode);
+    hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
+    return hash ^ (hash >> 6);
+  }
+
+  int _finish(int hash) {
+    hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
+    hash = hash ^ (hash >> 11);
+    return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
+  }
+}

--- a/lib/src/xml/nodes/attribute.dart
+++ b/lib/src/xml/nodes/attribute.dart
@@ -31,4 +31,7 @@ class XmlAttribute extends XmlNode with XmlHasName, XmlHasParent<XmlNode> {
 
   @override
   void accept(XmlVisitor visitor) => visitor.visitAttribute(this);
+
+  @override
+  List<Object?> get comparable => [name, value];
 }

--- a/lib/src/xml/nodes/cdata.dart
+++ b/lib/src/xml/nodes/cdata.dart
@@ -15,4 +15,7 @@ class XmlCDATA extends XmlData {
 
   @override
   void accept(XmlVisitor visitor) => visitor.visitCDATA(this);
+
+  @override
+  List<Object?> get comparable => [text];
 }

--- a/lib/src/xml/nodes/comment.dart
+++ b/lib/src/xml/nodes/comment.dart
@@ -15,4 +15,7 @@ class XmlComment extends XmlData {
 
   @override
   void accept(XmlVisitor visitor) => visitor.visitComment(this);
+
+  @override
+  List<Object?> get comparable => [text];
 }

--- a/lib/src/xml/nodes/declaration.dart
+++ b/lib/src/xml/nodes/declaration.dart
@@ -46,6 +46,9 @@ class XmlDeclaration extends XmlNode
 
   @override
   void accept(XmlVisitor visitor) => visitor.visitDeclaration(this);
+
+  @override
+  List<Object?> get comparable => attributes;
 }
 
 /// Supported attribute node types.

--- a/lib/src/xml/nodes/doctype.dart
+++ b/lib/src/xml/nodes/doctype.dart
@@ -26,4 +26,8 @@ class XmlDoctype extends XmlNode with XmlHasParent<XmlNode> {
 
   @override
   void accept(XmlVisitor visitor) => visitor.visitDoctype(this);
+
+  @override
+  // TODO: implement comparable
+  List<Object?> get comparable => [name, externalId, internalSubset];
 }

--- a/lib/src/xml/nodes/document.dart
+++ b/lib/src/xml/nodes/document.dart
@@ -1,13 +1,17 @@
+import 'package:collection/collection.dart';
+
 import '../../../xml_events.dart';
 import '../entities/entity_mapping.dart';
 import '../exceptions/parser_exception.dart';
 import '../exceptions/tag_exception.dart';
 import '../mixins/has_children.dart';
 import '../visitors/visitor.dart';
+import 'comment.dart';
 import 'declaration.dart';
 import 'doctype.dart';
 import 'element.dart';
 import 'node.dart';
+import 'text.dart';
 
 /// XML document node.
 class XmlDocument extends XmlNode with XmlHasChildren<XmlNode> {
@@ -100,6 +104,17 @@ class XmlDocument extends XmlNode with XmlHasChildren<XmlNode> {
 
   @override
   void accept(XmlVisitor visitor) => visitor.visitDocument(this);
+
+  @override
+  List<Object?> get comparable =>
+      // empty text nodes and comments are not relevant for the data structure
+      children
+          .whereNot(
+            (element) =>
+                (element is XmlText && element.text.trim().isEmpty) ||
+                element is XmlComment,
+          )
+          .toList();
 }
 
 /// Supported child node types.

--- a/lib/src/xml/nodes/document_fragment.dart
+++ b/lib/src/xml/nodes/document_fragment.dart
@@ -39,6 +39,9 @@ class XmlDocumentFragment extends XmlNode with XmlHasChildren<XmlNode> {
 
   @override
   void accept(XmlVisitor visitor) => visitor.visitDocumentFragment(this);
+
+  @override
+  List<Object?> get comparable => children;
 }
 
 /// Supported child node types.

--- a/lib/src/xml/nodes/element.dart
+++ b/lib/src/xml/nodes/element.dart
@@ -1,12 +1,17 @@
+import 'package:collection/collection.dart';
+
 import '../enums/node_type.dart';
 import '../mixins/has_attributes.dart';
 import '../mixins/has_children.dart';
 import '../mixins/has_name.dart';
 import '../mixins/has_parent.dart';
 import '../utils/name.dart';
+import '../utils/namespace.dart';
 import '../visitors/visitor.dart';
 import 'attribute.dart';
+import 'comment.dart';
 import 'node.dart';
+import 'text.dart';
 
 /// XML element node.
 class XmlElement extends XmlNode
@@ -46,6 +51,33 @@ class XmlElement extends XmlNode
 
   @override
   void accept(XmlVisitor visitor) => visitor.visitElement(this);
+
+  @override
+  List<Object?> get comparable => [
+        name,
+        // when comparing two xml data models, it is not at all relevant how
+        // particular namespaces are prefixed. Only the data should be compared.
+        // Removing all namespace declarations hence
+        attributes
+            .whereNot(
+              (attribute) =>
+                  attribute.name.prefix == xmlns ||
+                  (attribute.name.prefix == null &&
+                      attribute.name.local == xmlns),
+            )
+            .toList()
+          // the order of attributes does not affect the data structure
+          ..sort(),
+        // empty text nodes and comments are not relevant for the data structure
+        children
+            .whereNot(
+              (element) =>
+                  (element is XmlText && element.text.trim().isEmpty) ||
+                  element is XmlComment,
+            )
+            .toList(),
+        isSelfClosing,
+      ];
 }
 
 /// Supported child node types.

--- a/lib/src/xml/nodes/node.dart
+++ b/lib/src/xml/nodes/node.dart
@@ -6,12 +6,14 @@ import '../mixins/has_text.dart';
 import '../mixins/has_visitor.dart';
 import '../mixins/has_writer.dart';
 import '../mixins/has_xml.dart';
+import '../mixins/xml_camparable.dart';
 
 /// Immutable abstract XML node.
 abstract class XmlNode extends Object
     with
         XmlAttributesBase,
         XmlChildrenBase,
+        XmlComparable,
         XmlHasText,
         XmlHasVisitor,
         XmlHasWriter,

--- a/lib/src/xml/nodes/processing.dart
+++ b/lib/src/xml/nodes/processing.dart
@@ -18,4 +18,7 @@ class XmlProcessing extends XmlData {
 
   @override
   void accept(XmlVisitor visitor) => visitor.visitProcessing(this);
+
+  @override
+  List<Object?> get comparable => [target, text];
 }

--- a/lib/src/xml/nodes/text.dart
+++ b/lib/src/xml/nodes/text.dart
@@ -15,4 +15,7 @@ class XmlText extends XmlData {
 
   @override
   void accept(XmlVisitor visitor) => visitor.visitText(this);
+
+  @override
+  List<Object?> get comparable => [text.trim()];
 }

--- a/lib/src/xml/utils/name.dart
+++ b/lib/src/xml/utils/name.dart
@@ -3,6 +3,7 @@ import 'package:meta/meta.dart';
 import '../mixins/has_parent.dart';
 import '../mixins/has_visitor.dart';
 import '../mixins/has_writer.dart';
+import '../mixins/xml_camparable.dart';
 import '../nodes/node.dart';
 import '../visitors/visitor.dart';
 import 'prefix_name.dart';
@@ -11,7 +12,12 @@ import 'token.dart';
 
 /// XML entity name.
 abstract class XmlName extends Object
-    with XmlHasVisitor, XmlHasWriter, XmlHasParent<XmlNode> {
+    with
+        XmlComparable,
+        XmlHasVisitor,
+        XmlHasWriter,
+        XmlHasParent<XmlNode>,
+        Comparable<XmlName> {
   /// Creates a qualified [XmlName] from a `local` name and an optional
   /// `prefix`.
   factory XmlName(String local, [String? prefix]) =>
@@ -52,11 +58,18 @@ abstract class XmlName extends Object
   void accept(XmlVisitor visitor) => visitor.visitName(this);
 
   @override
-  // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  bool operator ==(Object other) =>
-      other is XmlName && other.qualified == qualified;
+  List<Object?> get comparable => [local, namespaceUri];
 
   @override
-  // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  int get hashCode => qualified.hashCode;
+  bool? additionalComparator(Object other) =>
+      other is XmlName && (other.local == local && other.prefix == prefix)
+          ? true
+          : null;
+
+  String get _compareToName => '$namespaceUri:$local';
+
+  @override
+  // comparing pseudo-namespace String preserving order of [namespaceUri]
+  int compareTo(XmlName other) =>
+      _compareToName.compareTo(other._compareToName);
 }

--- a/test/namespace_test.dart
+++ b/test/namespace_test.dart
@@ -32,4 +32,28 @@ void main() {
       }
     }
   });
+  test('data equality across namespaces', () {
+    final documentPrefixed = XmlDocument.parse(
+        '<xhtml:html xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:unused="http://schema.example.com/unused">'
+        '  <xhtml:body xhtml:lang="en"/>'
+        '</xhtml:html>');
+
+    final document =
+        XmlDocument.parse('<html xmlns="http://www.w3.org/1999/xhtml">'
+            '  <body lang="en"/>'
+            '</html>');
+
+    expect(document, documentPrefixed);
+  });
+  test('argument order compares', () {
+    final unorderedDocument = XmlDocument.parse('<html>'
+        '  <body lang="en" id="body"/>'
+        '</html>');
+
+    final document = XmlDocument.parse('<html >'
+        '  <body id="body" lang="en"/>'
+        '</html>');
+
+    expect(document, unorderedDocument);
+  });
 }


### PR DESCRIPTION
- implement equality operators for XmlNode
- better handle namespace equality when comparing present XML data

Those changes are particularly relevant when directly comparing unknown XML encoded data. The equality operator - as documented - is not meant to check whether the current *representation* of the data is equal, but just whether the data *itself* is equal. In order to reach there, e.g. empty text nodes or comments are ignored, attributes are ordered and namespaces are compared according to their URI, not their prefix.

Signed-off-by: TheOneWithTheBraid <the-one@with-the-braid.cf>